### PR TITLE
Remove check inputValue equal to new value

### DIFF
--- a/src/app/date-picker/date-picker.component.ts
+++ b/src/app/date-picker/date-picker.component.ts
@@ -244,9 +244,6 @@ export class DatePickerComponent implements OnChanges,
   }
 
   writeValue(value: CalendarValue): void {
-    if (this.inputValue === value) {
-      return;
-    }
     this.inputValue = value;
 
     if (value || value === '') {


### PR DESCRIPTION
سلام
برای خالی کردن فیلد تاریخ (به عنوان مثال در هنگام ریست کردن یک فرم جستجو) مقدار متغیر ngModel رو برابر null قرار می‌دهم، برای اولین بار درست کار میکند ولی اگر برای بار دوم فیلد تاریخ را پر کنیم و بخواهیم مجدد فرم را ریست کنیم این مورد درست کار نمی‌کند و فیلد تاریخ پاک نمی‌شود.
دلیلش هم خط چک مقدار برابری مقدار جدید با مقدار inputValue در متد writeValue می باشد زیرا در این حالت هر دو مقدار برابر null می‌باشد .
اگر اشتباه نکنم این شرط برای این بکار رفته که کاربر با انتخاب تاریخ تکراری فیلد را خالی کند
در این پول ریکوئست فقط همین شرط حذف شده است.